### PR TITLE
Removed the './' path in the prettier workflow

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -28,4 +28,4 @@ jobs:
         uses: creyD/prettier_action@v4.2
         with:
           commit_message: "Code Indented!"
-          prettier_options: --write **/*.{js,css,html,json,ts,tsx,jsx} --config ./.prettierrc
+          prettier_options: --write **/*.{js,css,html,json,ts,tsx,jsx} --config .prettierrc


### PR DESCRIPTION
# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)